### PR TITLE
Use req.socket for size of response when it is available

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+1.0.1 - October 18, 2017
+------------------------
+Support for response size in newer versions of node
+
 1.0.0 - December 22, 2013
 -------------------------
 :sparkles:

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ exports.token('time', function (req) {
  */
 
 exports.token('size', function (req, res) {
-  return res._sent;
+  return req.socket ? req.socket.bytesWritten : res._sent;
 });
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "name": "response-summary",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
@ivolo this ok? Makes `size` work for me with node@8, expressjs@4.